### PR TITLE
Change TouchableHighlight to TouchableOpacity

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -11,7 +11,7 @@ var {
 } = React;
 var {
   Animated,
-  TouchableHighlight,
+  TouchableOpacity,
   View,
 } = require('react-native');
 var TimerMixin = require('react-timer-mixin');
@@ -140,12 +140,12 @@ var Lightbox = React.createClass({
         onLayout={() => {}}
       >
         <Animated.View style={{opacity: this.state.layoutOpacity}}>
-          <TouchableHighlight
+          <TouchableOpacity
             underlayColor={this.props.underlayColor}
             onPress={this.open}
           >
             {this.props.children}
-          </TouchableHighlight>
+          </TouchableOpacity>
         </Animated.View>
         {this.props.navigator ? false : <LightboxOverlay {...this.getOverlayProps()} />}
       </View>


### PR DESCRIPTION
Correct the error `Touchable child must either be native or forward setNativeProps to a native component" error on the #next branch`, the same reported here:
https://github.com/react-native-training/react-native-elements/issues/407