### PR TITLE
Fixes for React 16 and RN 50

### DIFF
--- a/Lightbox.js
+++ b/Lightbox.js
@@ -7,8 +7,9 @@ var React = require('react');
 var {
   Children,
   cloneElement,
-  PropTypes,
 } = React;
+var PropTypes = require('prop-types');
+var createReactClass = require('create-react-class');
 var {
   Animated,
   TouchableHighlight,
@@ -18,7 +19,7 @@ var TimerMixin = require('react-timer-mixin');
 
 var LightboxOverlay = require('./LightboxOverlay');
 
-var Lightbox = React.createClass({
+var Lightbox = createReactClass({
   mixins: [TimerMixin],
 
   propTypes: {

--- a/LightboxOverlay.js
+++ b/LightboxOverlay.js
@@ -3,10 +3,8 @@
  */
 'use strict';
 
-var React = require('react');
-var {
-  PropTypes,
-} = React;
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var {
   Animated,
   Dimensions,
@@ -25,7 +23,7 @@ var WINDOW_WIDTH = Dimensions.get('window').width;
 // Translation threshold for closing the image preview
 var CLOSING_THRESHOLD = 100;
 
-var LightboxOverlay = React.createClass({
+var LightboxOverlay = createReactClass({
   propTypes: {
     origin: PropTypes.shape({
       x: PropTypes.number,

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ npm install --save react-native-lightbox
 `navigator` property is optional but recommended on iOS, see next section for `Navigator` configuration.
 
 ```js
+vart createReactClass = require('create-react-class');
 var Lightbox = require('react-native-lightbox');
 
-var LightboxView = React.createClass({
+var LightboxView = createReactClass({
   render: function() {
     return (
       <Lightbox navigator={this.props.navigator}>
@@ -31,10 +32,12 @@ var LightboxView = React.createClass({
 
 ### Navigator setup/Android support
 
-For android support you must pass a reference to a `Navigator` since it does not yet have the `Modal` component and is not on the official todo list. See the `Example` project for a complete example. 
+For android support you must pass a reference to a `Navigator` since it does not yet have the `Modal` component and is not on the official todo list. See the `Example` project for a complete example.
 
 ```js
-var MyApp = React.createClass({
+var createReactClass = require('create-react-class');
+
+var MyApp = createReactClass({
   renderScene: function(route, navigator) {
     var Component = route.component;
 
@@ -77,11 +80,10 @@ var MyApp = React.createClass({
 
 ![Demo](https://cloud.githubusercontent.com/assets/378279/9074360/16eac5d6-3b09-11e5-90af-a69980e9f4be.gif)
 
-## Example 
+## Example
 
-Check full example in the `Example` folder. 
+Check full example in the `Example` folder.
 
 ## License
 
 [MIT License](http://opensource.org/licenses/mit-license.html). © Joel Arvidsson
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save react-native-lightbox
 `navigator` property is optional but recommended on iOS, see next section for `Navigator` configuration.
 
 ```js
-vart createReactClass = require('create-react-class');
+var createReactClass = require('create-react-class');
 var Lightbox = require('react-native-lightbox');
 
 var LightboxView = createReactClass({

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "react-native-view-transformer": "shoutem/react-native-view-transformer#master",
     "create-react-class": "^15.6.2",
+    "prop-types": "^15.5.10",
     "react-timer-mixin": "^0.13.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/oblador/react-native-lightbox",
   "dependencies": {
-    "react-native-view-transformer": "shoutem/react-native-view-transformer#feature/update-dependency",
+    "react-native-view-transformer": "shoutem/react-native-view-transformer#master",
     "create-react-class": "^15.6.2",
     "react-timer-mixin": "^0.13.3"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "homepage": "https://github.com/oblador/react-native-lightbox",
   "dependencies": {
-    "react-native-view-transformer": "ldn0x7dc/react-native-view-transformer#f7e028b6566022deac4e523052e74c2c63a4af7e",
+    "react-native-view-transformer": "shoutem/react-native-view-transformer#update-dependency",
+    "create-react-class": "^15.6.2",
     "react-timer-mixin": "^0.13.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/oblador/react-native-lightbox",
   "dependencies": {
-    "react-native-view-transformer": "shoutem/react-native-view-transformer#update-dependency",
+    "react-native-view-transformer": "shoutem/react-native-view-transformer#feature/update-dependency",
     "create-react-class": "^15.6.2",
     "react-timer-mixin": "^0.13.3"
   }


### PR DESCRIPTION
Switched from `React.createClass` to `createReactClass` (`create-react-class` package).
Switched from `React.PropTypes` to `PropTypes` (`prop-types` package).

Updated dependencies for forked `react-native-view-transformer`.